### PR TITLE
fix: make schema.org markup valid

### DIFF
--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -5,16 +5,18 @@ const Form = ({
   children,
   submitHandler,
   modifier = '',
+  id,
 }: {
   children: ReactNode;
   submitHandler: any;
   modifier?: string;
+  id?: string;
 }) => {
   const withModifier = modifier ? styles[`wrapper--${modifier}`] : '';
   const classes = `${styles.wrapper} ${withModifier}`;
 
   return (
-    <form onSubmit={submitHandler} className={classes}>
+    <form onSubmit={submitHandler} className={classes} id={id}>
       {children}
     </form>
   );

--- a/src/components/Layouts/Layout.tsx
+++ b/src/components/Layouts/Layout.tsx
@@ -7,7 +7,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { ReactElement, ReactNode, useEffect, useRef } from 'react';
 import { useIntl } from 'react-intl';
-import { WebSite, WithContext } from 'schema-dts';
+import { SearchAction, WebSite, WithContext } from 'schema-dts';
 import styles from './Layout.module.scss';
 
 const Layout = ({
@@ -40,11 +40,19 @@ const Layout = ({
     creator: { '@id': `${settings.url}/#branding` },
     editor: { '@id': `${settings.url}/#branding` },
     inLanguage: settings.locales.defaultLocale,
-    potentialAction: {
-      '@type': 'SearchAction',
-      target: `${settings.url}/recherche?s={query}`,
-      query: 'required',
-    },
+    potentialAction: { '@id': `${settings.url}/#search` },
+  };
+
+  type QueryAction = SearchAction & {
+    'query-input': string;
+  };
+
+  const searchActionSchema: QueryAction = {
+    '@type': 'SearchAction',
+    '@id': `${settings.url}/#search`,
+    target: `${settings.url}/recherche?s={query}`,
+    query: 'required',
+    'query-input': 'required name=query',
   };
 
   return (
@@ -93,6 +101,12 @@ const Layout = ({
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(schemaJsonLd) }}
+        ></script>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(searchActionSchema),
+          }}
         ></script>
       </Head>
       <noscript>

--- a/src/components/PostPreview/PostPreview.tsx
+++ b/src/components/PostPreview/PostPreview.tsx
@@ -57,6 +57,7 @@ const PostPreview = ({
     dateModified: updateDate.toISOString(),
     datePublished: publicationDate.toISOString(),
     editor: { '@id': `${settings.url}/#branding` },
+    headline: title,
     image: featuredImage?.sourceUrl,
     inLanguage: settings.locales.defaultLocale,
     isBasedOn: `${settings.url}/article/${slug}`,

--- a/src/components/SearchForm/SearchForm.tsx
+++ b/src/components/SearchForm/SearchForm.tsx
@@ -34,7 +34,7 @@ const SearchForm = ({ isOpened }: { isOpened: boolean }) => {
           description: 'SearchForm : form title',
         })}
       </div>
-      <Form submitHandler={launchSearch} modifier="search">
+      <Form submitHandler={launchSearch} modifier="search" id="search">
         <label htmlFor="search-query" className="screen-reader-text">
           {intl.formatMessage({
             defaultMessage: 'Keywords:',

--- a/src/pages/article/[slug].tsx
+++ b/src/pages/article/[slug].tsx
@@ -120,6 +120,7 @@ const SingleArticle: NextPageWithLayout<ArticleProps> = ({
     datePublished: publicationDate.toISOString(),
     discussionUrl: `${articleUrl}/#comments`,
     editor: { '@id': `${settings.url}/#branding` },
+    headline: title,
     image: featuredImage?.sourceUrl,
     inLanguage: settings.locales.defaultLocale,
     isPartOf: {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -152,7 +152,6 @@ const Home: NextPageWithLayout<HomePageProps> = ({
   const webpageSchema: WebPage = {
     '@id': `${settings.url}/#home`,
     '@type': 'WebPage',
-    breadcrumb: { '@id': `${settings.url}/#breadcrumb` },
     name: pageTitle,
     description: pageDescription,
     author: { '@id': `${settings.url}/#branding` },

--- a/src/pages/mentions-legales.tsx
+++ b/src/pages/mentions-legales.tsx
@@ -77,6 +77,7 @@ const LegalNotice: NextPageWithLayout = () => {
     dateModified: updateDate.toISOString(),
     datePublished: publicationDate.toISOString(),
     editor: { '@id': `${settings.url}/#branding` },
+    headline: title,
     inLanguage: settings.locales.defaultLocale,
     license: 'https://creativecommons.org/licenses/by-sa/4.0/deed.fr',
     mainEntityOfPage: { '@id': `${pageUrl}` },

--- a/src/pages/projet/[slug].tsx
+++ b/src/pages/projet/[slug].tsx
@@ -78,6 +78,7 @@ const Project: NextPageWithLayout<ProjectProps> = ({
     dateModified: updateDate.toISOString(),
     datePublished: publicationDate.toISOString(),
     editor: { '@id': `${settings.url}/#branding` },
+    headline: title,
     thumbnailUrl: meta.hasCover ? `/projects/${id}.jpg` : '',
     image: meta.hasCover ? `/projects/${id}.jpg` : '',
     inLanguage: settings.locales.defaultLocale,

--- a/src/pages/projets.tsx
+++ b/src/pages/projets.tsx
@@ -66,6 +66,7 @@ const Projects = ({ projects }: { projects: Project[] }) => {
     dateModified: updateDate.toISOString(),
     datePublished: publicationDate.toISOString(),
     editor: { '@id': `${settings.url}/#branding` },
+    headline: meta.title,
     inLanguage: settings.locales.defaultLocale,
     license: 'https://creativecommons.org/licenses/by-sa/4.0/deed.fr',
     mainEntityOfPage: { '@id': `${pageUrl}` },

--- a/src/pages/sujet/[slug].tsx
+++ b/src/pages/sujet/[slug].tsx
@@ -79,7 +79,7 @@ const Topic: NextPageWithLayout<TopicProps> = ({ topic, allTopics }) => {
   const updateDate = new Date(topic.dates.update);
 
   const articleSchema: Article = {
-    '@id': `${settings.url}/topic`,
+    '@id': `${settings.url}/#topic`,
     '@type': 'Article',
     name: topic.title,
     description: topic.intro,
@@ -90,6 +90,7 @@ const Topic: NextPageWithLayout<TopicProps> = ({ topic, allTopics }) => {
     dateModified: updateDate.toISOString(),
     datePublished: publicationDate.toISOString(),
     editor: { '@id': `${settings.url}/#branding` },
+    headline: topic.title,
     thumbnailUrl: topic.featuredImage?.sourceUrl,
     image: topic.featuredImage?.sourceUrl,
     inLanguage: settings.locales.defaultLocale,

--- a/src/pages/thematique/[slug].tsx
+++ b/src/pages/thematique/[slug].tsx
@@ -78,7 +78,7 @@ const Thematic: NextPageWithLayout<ThematicProps> = ({
   const updateDate = new Date(thematic.dates.update);
 
   const articleSchema: Article = {
-    '@id': `${settings.url}/thematic`,
+    '@id': `${settings.url}/#thematic`,
     '@type': 'Article',
     name: thematic.title,
     description: thematic.intro,
@@ -89,6 +89,7 @@ const Thematic: NextPageWithLayout<ThematicProps> = ({
     dateModified: updateDate.toISOString(),
     datePublished: publicationDate.toISOString(),
     editor: { '@id': `${settings.url}/#branding` },
+    headline: thematic.title,
     inLanguage: settings.locales.defaultLocale,
     isPartOf: { '@id': `${settings.url}/blog` },
     license: 'https://creativecommons.org/licenses/by-sa/4.0/deed.fr',


### PR DESCRIPTION
Squashed commit of the following:

commit 49c1b3b1556a0eb91c429a961fedd2bded8ffd47
Author: Armand Philippot <git@armandphilippot.com>
Date:   Wed Feb 16 15:17:52 2022 +0100

    chore: add headline field to blogPosting schema

commit 42214c6f032cc899ec252a9387be35dcad738546
Author: Armand Philippot <git@armandphilippot.com>
Date:   Wed Feb 16 15:09:11 2022 +0100

    chore: update the searchAction markup and add query-input

    Google was complaining about "query-input" which is not in Schema.org
    representation. So I added it.

commit 5f29226d937cbdcd262df2793f1588435d850f02
Author: Armand Philippot <git@armandphilippot.com>
Date:   Wed Feb 16 14:32:14 2022 +0100

    chore: remove breadcrumb from homepage

    The breadcrumb is not displayed on the homepage, so the breadcrumb
    field should not appear inside Schema markup.