### PR TITLE
fix: prevent cropped plus/minus icon on widgets

### DIFF
--- a/src/components/WidgetParts/ExpandableWidget/ExpandableWidget.module.scss
+++ b/src/components/WidgetParts/ExpandableWidget/ExpandableWidget.module.scss
@@ -116,6 +116,7 @@
   gap: var(--spacing-md);
   width: 100%;
   min-height: var(--header-height);
+  padding: 0;
   position: sticky;
   top: 0;
   z-index: 3;


### PR DESCRIPTION
Because of the default padding on button element, in some browsers the plus/minus icon on widgets was cropped.