### PR TITLE
fix(media-queries): use pixel based media queries

### DIFF
--- a/src/components/organisms/toolbar/toolbar.module.scss
+++ b/src/components/organisms/toolbar/toolbar.module.scss
@@ -50,7 +50,10 @@
 
   @media screen and (min-width: #{var.get-breakpoint("sm")}) {
     .modal {
-      min-width: fun.convert-px(380);
+      &--search,
+      &--settings {
+        min-width: fun.convert-px(380);
+      }
     }
   }
 }

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -38,11 +38,11 @@ $ratios: (
 /// @prop {String} keys - Keys are identifiers mapped to a given length
 /// @prop {Map} values - Values are actual breakpoints expressed in pixels
 $breakpoints: (
-  "2xs": fun.convert-px(500, "em"),
-  "xs": fun.convert-px(600, "em"),
-  "sm": fun.convert-px(800, "em"),
-  "md": fun.convert-px(1280, "em"),
-  "lg": fun.convert-px(1600, "em"),
+  "2xs": 500px,
+  "xs": 600px,
+  "sm": 800px,
+  "md": 1280px,
+  "lg": 1600px,
 );
 
 // I cannot declare the following function with others functions due to module


### PR DESCRIPTION
Everything was working fine with Firefox but it seems Chromium still has issues with `em` unit in media queries. The toolbar modals (search, settings and also main nav) was not displaying correctly on small devices. Some styles was missing. By switching to pixels based media queries, the bug seems fixed.